### PR TITLE
Fix: PWA updates not showing automatically

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,18 @@
   from = "/*"
   to = "/index.html"
   status = 200
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    cache-control = "max-age=31536000, public, immutable"
+
+[[headers]]
+  for = "/index.html"
+  [headers.values]
+    cache-control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/ngsw.json"
+  [headers.values]
+    cache-control = "public, max-age=0, must-revalidate"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { NavigationEnd, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { SwUpdate, VersionReadyEvent } from '@angular/service-worker';
 import { TranslateModule } from '@ngx-translate/core';
 import { filter } from 'rxjs/operators';
 import { AuthService } from './core/services/auth.service';
@@ -26,7 +27,8 @@ export class AppComponent implements OnInit {
     private authService: AuthService,
     private router: Router,
     private themeService: ThemeService,
-    private languageService: LanguageService
+    private languageService: LanguageService,
+    private swUpdate: SwUpdate
   ) {}
 
   ngOnInit() {
@@ -42,6 +44,17 @@ export class AppComponent implements OnInit {
     ).subscribe(() => {
       this.updateNavVisibility();
     });
+
+    // Handle PWA updates
+    if (this.swUpdate.isEnabled) {
+      this.swUpdate.versionUpdates.pipe(
+        filter((evt): evt is VersionReadyEvent => evt.type === 'VERSION_READY')
+      ).subscribe(() => {
+        if (confirm('A new version of the app is available. Update now?')) {
+          window.location.reload();
+        }
+      });
+    }
   }
 
   private updateNavVisibility() {


### PR DESCRIPTION
Resolves #4

This PR fixes an issue where the app's service worker and `index.html` were being aggressively cached. This caused users to see old deployments of the app unless they manually cleared their browser cache. 

**Fixes:**
1. Modified `netlify.toml` to disable caching for `index.html` and `ngsw.json`.
2. Added `SwUpdate` logic in `app.component.ts` to prompt users to reload the page whenever a new service worker update is downloaded in the background.